### PR TITLE
FileToWebPath for filenames containing "public"

### DIFF
--- a/plugin/app/com/ee/assets/transformers/FileToWebPath.scala
+++ b/plugin/app/com/ee/assets/transformers/FileToWebPath.scala
@@ -16,7 +16,7 @@ class FileToWebPath(info: AssetsInfo) extends Transformer[Unit,Unit] {
     if (!p.contains(info.filePath)) {
       logger.warn(s"$p doesn't contain ${info.filePath} - so nothing to replace")
     }
-    val out = p.replace(info.filePath, info.webPath)
+    val out = p.replaceFirst(info.filePath, info.webPath)
 
     if (out.startsWith("/")) out else s"/$out"
   }


### PR DESCRIPTION
When using assets-loader with a file containing the `public` string, the generated url (in non-concatenated mode) was not generated correctly. The `public` string was replaced by `assets` in the filename.

Ex: for the file `css/public.css`, the url `/assets/css/assets.css` was generated instead of `/assets/css/public.css`.

This PR fixes this issue.
