### PR TITLE
Allow info to be passed in as an optional constructor parameter to Loade...

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ The loader will concatenate singleFile.js, app.js and helper.js into one file, m
 
 ### Api
 
-    //Loader(deployer:Option[Deployer] = None, mode : Mode.Mode, config : Configuration, closureCompilerOptions : Option[CompilerOptions] = None)
+    /**
+      Loader(
+        deployer:Option[Deployer] = None,
+        mode : Mode.Mode,
+        config : Configuration,
+        closureCompilerOptions : Option[CompilerOptions] = None,
+        info : AssetsInfo = AssetsInfo("assets", "public")
+      )
+    */
     val loader = new com.ee.assets.Loader(None, Play.current.mode, Play.current.configuration)
 
     loader.scripts("name")("path_to_scripts_folder_or_file", ...)
@@ -90,7 +98,7 @@ You can pass in your own closure compiler options when you are instantiating the
 #### Add the Asset Loader as a dependency to your build:
 
       val assetsLoader = "com.ee" %% "assets-loader" % "0.12.1"
-      
+
       // snapshot version
       //val assetsLoader = "com.ee" %% "assets-loader" % "0.12.2-SNAPSHOT"
 

--- a/example/example-play-app/app/views/Helper.scala
+++ b/example/example-play-app/app/views/Helper.scala
@@ -3,6 +3,7 @@ package views
 import play.api.Play
 import java.io.InputStream
 import com.ee.assets.deployment.{ContentInfo, Deployer}
+import com.ee.assets.models.AssetsInfo
 
 object Helper{
 
@@ -18,6 +19,6 @@ object Helper{
     }
   }
 
-  val loader = new com.ee.assets.Loader(None, Play.current.mode, Play.current.configuration)
+  val loader = new com.ee.assets.Loader(None, Play.current.mode, Play.current.configuration, info = AssetsInfo("context/assets", "public"))
   val deployLoader = new com.ee.assets.Loader(Some(deployer), Play.current.mode, Play.current.configuration)
 }

--- a/example/example-play-app/conf/application.conf
+++ b/example/example-play-app/conf/application.conf
@@ -13,6 +13,8 @@ application.langs="en"
 
 #logger.assets.loader=TRACE
 
+application.context=/context
+
 assetsLoader: {
   dev : {
     concatenate:true
@@ -33,4 +35,3 @@ assetsLoader: {
     gzip: true
   }
 }
-

--- a/plugin/app/com/ee/assets/Loader.scala
+++ b/plugin/app/com/ee/assets/Loader.scala
@@ -11,7 +11,20 @@ import java.net.URL
 import play.api.templates.Html
 import play.api.{Play, Configuration, Mode}
 
-class Loader(deployer: Option[Deployer] = None, mode: Mode.Mode, config: Configuration, closureCompilerOptions: Option[CompilerOptions] = None) {
+/**
+ *
+ * @param deployer
+ * @param mode
+ * @param config
+ * @param closureCompilerOptions
+ * @param info - path info that maps the web path (when loading the assets via the server) -> file path (the location of the files in the project)
+ */
+class Loader(
+              deployer: Option[Deployer] = None,
+              mode: Mode.Mode,
+              config: Configuration,
+              closureCompilerOptions: Option[CompilerOptions] = None,
+              info: AssetsInfo = AssetsInfo("assets", "public")) {
 
   private lazy val JsConfig: AssetsLoaderConfig = validateConfig(AssetsLoaderConfig.fromAppConfiguration(mode.toString.toLowerCase, Suffix.js, config))
   private lazy val CssConfig: AssetsLoaderConfig = validateConfig(AssetsLoaderConfig.fromAppConfiguration(mode.toString.toLowerCase, Suffix.css, config))
@@ -24,8 +37,6 @@ class Loader(deployer: Option[Deployer] = None, mode: Mode.Mode, config: Configu
       c
     }
   }
-
-  private lazy val Info: AssetsInfo = AssetsInfo("assets", "public")
 
   val generatedDir = com.ee.utils.play.generatedFolder
 
@@ -150,7 +161,7 @@ class Loader(deployer: Option[Deployer] = None, mode: Mode.Mode, config: Configu
     val read = new PlayResourceReader
     val namer = new CommonRootNamer(concatPrefix, suffix)
     val concat = new Concatenator(namer)
-    val toWebPath = new FileToWebPath(Info)
+    val toWebPath = new FileToWebPath(info)
     val gzip = new Gzip()
     val stringWriter = if (config.deploy) new StringDeploy(deployer.get).run _ else new Writer(writeToGeneratedFolder).run _ andThen toWebPath.run _
     val byteWriter = if (config.deploy) new ByteArrayDeploy(deployer.get).run _ else new ByteArrayWriter(pathToFile).run _ andThen toWebPath.run _
@@ -172,7 +183,7 @@ class Loader(deployer: Option[Deployer] = None, mode: Mode.Mode, config: Configu
 
     import play.api.Play.current
     logger.debug(s"[toElements]: $paths")
-    def publicDir(p: String) = s"${Info.filePath}/$p"
+    def publicDir(p: String) = s"${info.filePath}/$p"
 
     val pathsAndUrls: Seq[(String, URL)] = paths.map {
       p =>


### PR DESCRIPTION
Fix for #27 - allow the end user to pass in an `AssetsInfo` case class that defines the web -> file path mapping.
