### PR TITLE
example of a different way of solving the rotating hosts use case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*.sublime-project
-*.sublime-workspace
+*.sublime-*
+atlassian-*

--- a/example/example-play-app/app/views/Helper.scala
+++ b/example/example-play-app/app/views/Helper.scala
@@ -1,24 +1,65 @@
 package views
 
-import play.api.Play
+import play.api.{Logger, Play}
 import java.io.InputStream
 import com.ee.assets.deployment.{ContentInfo, Deployer}
 import com.ee.assets.models.SimpleAssetsInfo
+import com.ee.assets.transformers.{SimpleDeployedElement, DeployedElement}
 
 object Helper{
 
   val deployer : Deployer = new Deployer {
-    override def deploy(filename: String, lastModified: Long, contents: => InputStream, info: ContentInfo): Either[String, String] = {
+    override def deploy(filename: String, lastModified: Long, contents: => InputStream, info: ContentInfo): Either[String, DeployedElement] = {
 
       //do your deployment here...
 
       println(filename)
       println(lastModified)
       println(info)
-      Right(s"http://some-non-existent-server.com/$filename")
+      Right(SimpleDeployedElement(s"http://some-non-existent-server.com/$filename"))
+    }
+  }
+
+  object ExternalHosts{
+
+    import Play.current
+
+    lazy val logger = Logger("external-hosts")
+
+    val configPath = "assets.hosts"
+    var hostsIndex = 0
+    import scala.collection.JavaConverters._
+
+    lazy val hosts = Play.configuration.getStringList(configPath).fold(List[String]())(_.asScala.toList)
+
+    def getNextHost = {
+      val host = ExternalHosts.hosts(ExternalHosts.hostsIndex)
+      if(ExternalHosts.hostsIndex == ExternalHosts.hosts.size-1)  ExternalHosts.hostsIndex = 0
+      else ExternalHosts.hostsIndex += 1
+      host
+    }
+  }
+
+  case class RotatingHostsDeployedElement(deployedPath: String, getHost: () => String) extends DeployedElement{
+    override def path: String = s"${getHost()}$deployedPath"
+  }
+
+  /**
+   * An example of rotating hosts for a deployed element.
+   */
+  val rotatingDeployer : Deployer = new Deployer {
+    override def deploy(filename: String, lastModified: Long, contents: => InputStream, info: ContentInfo): Either[String, DeployedElement] = {
+
+      //do your deployment here...
+
+      println(filename)
+      println(lastModified)
+      println(info)
+      Right(RotatingHostsDeployedElement(filename, ExternalHosts.getNextHost _))
     }
   }
 
   val loader = new com.ee.assets.Loader(None, Play.current.mode, Play.current.configuration, info = SimpleAssetsInfo("assets", "public"))
   val deployLoader = new com.ee.assets.Loader(Some(deployer), Play.current.mode, Play.current.configuration)
+  val rotatingHostsLoader = new com.ee.assets.Loader(Some(rotatingDeployer), Play.current.mode, Play.current.configuration)
 }

--- a/example/example-play-app/app/views/main.scala.html
+++ b/example/example-play-app/app/views/main.scala.html
@@ -12,6 +12,7 @@
         @views.Helper.loader.css("example")( "stylesheets" )
         @views.Helper.loader.scripts("example")( "javascripts/example" )
         @views.Helper.deployLoader.scripts("example")( "javascripts/example" )
+        @views.Helper.rotatingHostsLoader.scripts("example")( "javascripts/example" )
     </head>
     <body>
       @content

--- a/example/example-play-app/conf/application.conf
+++ b/example/example-play-app/conf/application.conf
@@ -33,3 +33,7 @@ assetsLoader: {
     gzip: true
   }
 }
+
+assets: {
+  hosts: ["http://localhost:9000/", "http://localhost1:9000/", "http://localhost2:9000/"]
+}

--- a/example/example-play-app/project/Build.scala
+++ b/example/example-play-app/project/Build.scala
@@ -7,7 +7,7 @@ object ApplicationBuild extends Build {
   val appName         = "example-221"
   val appVersion      = "1.0-SNAPSHOT"
 
-  val assetsLoader = "com.ee" %% "assets-loader" % "0.12.3-SNAPSHOT"
+  val assetsLoader = "com.ee" %% "assets-loader" % "0.12.4-SNAPSHOT"
 
   val appDependencies = Seq(assetsLoader)
 

--- a/plugin/app/com/ee/assets/deployment/Deployer.scala
+++ b/plugin/app/com/ee/assets/deployment/Deployer.scala
@@ -2,6 +2,8 @@ package com.ee.assets.deployment
 
 import java.io.InputStream
 
+import com.ee.assets.transformers.DeployedElement
+
 
 trait Deployer {
 
@@ -11,9 +13,11 @@ trait Deployer {
     * @param contents the file contents - called by name
     * @return the path to the deployed file
     */
-  def deploy(filename: String,  lastModified: Long, contents: => InputStream, info : ContentInfo): Either[String,String]
+  def deploy(filename: String,  lastModified: Long, contents: => InputStream, info : ContentInfo): Either[String,DeployedElement]
 
 }
+
+
 
 case class ContentInfo(contentType:String, contentEncoding:Option[String] = None)
 

--- a/plugin/app/com/ee/assets/transformers/Deploy.scala
+++ b/plugin/app/com/ee/assets/transformers/Deploy.scala
@@ -1,8 +1,9 @@
 package com.ee.assets.transformers
 
+import java.io.{ByteArrayInputStream, InputStream}
+
 import com.ee.assets.deployment.{ContentInfo, Deployer}
 import com.ee.log.Logger
-import java.io.{InputStream, ByteArrayInputStream}
 
 abstract class BaseDeploy[A](d: Deployer) extends Transformer[A, Unit] {
 
@@ -12,13 +13,13 @@ abstract class BaseDeploy[A](d: Deployer) extends Transformer[A, Unit] {
 
   protected def encoding: Option[String]
 
-  override def run(elements: Seq[Element[A]]): Seq[PathElement] = {
+  override def run(elements: Seq[Element[A]]): Seq[DeployedElement] = {
     elements.map {
       e =>
         def contentType = if (e.path.endsWith(".js")) "text/javascript" else "text/css"
         val is: InputStream = getInputStream(e.contents)
         d.deploy(e.path, e.lastModified.getOrElse(0), is, ContentInfo(contentType, encoding)) match {
-          case Right(p) => Some(PathElement(p))
+          case Right(p) => Some(p)
           case Left(err) => {
             logger.warn(s"Error deploying: ${e.path}")
             None

--- a/plugin/app/com/ee/assets/transformers/Element.scala
+++ b/plugin/app/com/ee/assets/transformers/Element.scala
@@ -1,16 +1,30 @@
 package com.ee.assets.transformers
 
-abstract class Element[A](val path: String,
-                              val contents: A,
-                              val lastModified: Option[Long])
+trait Element[A] {
+  def path: String
 
-case class ContentElement[A](override val path: String,
-                      override val contents: A,
-                      override val lastModified: Option[Long])
-  extends Element[A](
-    path,
-    contents,
-    lastModified
-  )
+  def contents: A
 
-case class PathElement(override val path: String) extends Element[Unit](path, Unit, None)
+  def lastModified: Option[Long]
+
+}
+
+abstract class BaseElement[A](val path: String,
+                          val contents: A,
+                          val lastModified: Option[Long]) extends Element[A]
+
+case class ContentElement[A](val path: String,
+                             val contents: A,
+                             val lastModified: Option[Long]) extends Element[A]
+
+case class PathElement(override val path: String) extends BaseElement[Unit](path, Unit, None)
+
+
+trait DeployedElement extends Element[Unit] {
+
+  override def lastModified: Option[Long] = None
+
+  override def contents: Unit = Unit
+}
+
+case class SimpleDeployedElement(val path:String) extends DeployedElement

--- a/plugin/it/com/ee/assets/transformers/ReadConcatMinifyWriteTest.scala
+++ b/plugin/it/com/ee/assets/transformers/ReadConcatMinifyWriteTest.scala
@@ -16,7 +16,7 @@ class ReadConcatMinifyWriteTest extends Specification with BaseIntegration{
       val read = ElementReader(readFn("it"))
 
       val concat = Concatenator(new PathNamer {
-        override def name[A](elements: Seq[Element[A]]): String = fileConcatted
+        override def name[A](elements: Seq[Element[A]], hashCode: Int): String = fileConcatted
       })
 
       val minify = JsMinifier()

--- a/plugin/it/com/ee/assets/transformers/ReadConcatWriteTest.scala
+++ b/plugin/it/com/ee/assets/transformers/ReadConcatWriteTest.scala
@@ -15,7 +15,8 @@ class ReadConcatWriteTest extends Specification with BaseIntegration{
 
       val read = ElementReader(readFn("it"))
       val concat = Concatenator(new PathNamer {
-        override def name[A](elements: Seq[Element[A]]): String = fileOut
+
+        override def name[A](elements: Seq[Element[A]], hashCode: Int): String = fileOut
       })
 
       val write = ElementWriter(writeFn("target"))

--- a/plugin/test/com/ee/assets/deployment/NullDeployer.scala
+++ b/plugin/test/com/ee/assets/deployment/NullDeployer.scala
@@ -2,11 +2,13 @@ package com.ee.assets.deployment
 
 import java.io.InputStream
 
+import com.ee.assets.transformers.{DeployedElement, SimpleDeployedElement}
+
 
 class NullDeployer extends Deployer{
-  def deploy(filename: String, lastModified: Long, contents : => InputStream, info : ContentInfo): Either[String,String] = try{
+  def deploy(filename: String, lastModified: Long, contents : => InputStream, info : ContentInfo): Either[String,DeployedElement] = try{
     val bytes = toByteArray(contents)
-    Right("/deployed" + filename)
+    Right(SimpleDeployedElement( s"/deployed$filename"))
   } catch {
     case e : Throwable => Left(e.getMessage)
   }

--- a/plugin/test/com/ee/assets/transformers/DeployTest.scala
+++ b/plugin/test/com/ee/assets/transformers/DeployTest.scala
@@ -1,8 +1,9 @@
 package com.ee.assets.transformers
 
-import org.specs2.mutable.Specification
-import com.ee.assets.deployment.{ContentInfo, Deployer}
 import java.io.InputStream
+
+import com.ee.assets.deployment.{ContentInfo, Deployer}
+import org.specs2.mutable.Specification
 
 class DeployTest extends Specification{
 
@@ -14,7 +15,7 @@ class DeployTest extends Specification{
                              filename: String,
                              lastModified: Long,
                              contents: => InputStream,
-                             info: ContentInfo): Either[String, String] = Right(s"deployed/$filename")
+                             info: ContentInfo): Either[String, DeployedElement] = Right(SimpleDeployedElement(s"deployed/$filename"))
       }
 
       val deploy = StringDeploy(mockDeploy)


### PR DESCRIPTION
The main change is that the Deployer#deploy trait now looks like: 

```
def deploy(filename: String,  lastModified: Long, contents: => InputStream, info : ContentInfo): Either[String,DeployedElement]
```

Where `DeployedElement` is: 

```
trait Element[A] {
  def path: String
  def contents: A
  def lastModified: Option[Long]
}

trait DeployedElement extends Element[Unit] {
  override def lastModified: Option[Long] = None
  override def contents: Unit = Unit
}
```

This allows for 3rd parties to provide their own implementation of `path` after they have successfully deployed.
